### PR TITLE
call onReady after the first block is arrived

### DIFF
--- a/src/main/java/org/adridadou/ethereum/RpcEthereumFacadeProvider.java
+++ b/src/main/java/org/adridadou/ethereum/RpcEthereumFacadeProvider.java
@@ -26,10 +26,12 @@ public class RpcEthereumFacadeProvider {
     private RpcEthereumFacadeProvider() {}
 
     public static EthereumFacade forRemoteNode(final String url, final ChainId chainId, EthereumRpcConfig config) {
-        Web3JFacade web3j = new Web3JFacade(Web3j.build(new HttpService(url)));
+        Web3j w3j = Web3j.build(new HttpService(url));
+		Web3JFacade web3j = new Web3JFacade(w3j);
         EthereumRpc ethRpc = new EthereumRpc(web3j, chainId, config);
         EthereumEventHandler eventHandler = new EthereumEventHandler();
-        eventHandler.onReady();
+        w3j.blockObservable(false).take(1).subscribe(b->eventHandler.onReady());
+        
         return CoreEthereumFacadeProvider.create(ethRpc, eventHandler, config);
     }
 


### PR DESCRIPTION
The first transaction on a rpc mostly will fail because eventHandler.getCurrentBlockNumber() is still 0. When then first block arrives the check 'blockParams.blockNumber > currentBlock + config.blockWaitLimit()' is true.