### PR TITLE
Ignore an exception that can (rarely) happen on block txs processing

### DIFF
--- a/src/main/java/org/adridadou/ethereum/rpc/EthereumRpc.java
+++ b/src/main/java/org/adridadou/ethereum/rpc/EthereumRpc.java
@@ -1,5 +1,6 @@
 package org.adridadou.ethereum.rpc;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,7 +10,6 @@ import org.adridadou.ethereum.propeller.Crypto;
 import org.adridadou.ethereum.propeller.EthereumBackend;
 import org.adridadou.ethereum.propeller.event.BlockInfo;
 import org.adridadou.ethereum.propeller.event.EthereumEventHandler;
-import org.adridadou.ethereum.propeller.exception.EthereumApiException;
 import org.adridadou.ethereum.propeller.values.ChainId;
 import org.adridadou.ethereum.propeller.values.EthAccount;
 import org.adridadou.ethereum.propeller.values.EthAddress;
@@ -145,7 +145,7 @@ public class EthereumRpc implements EthereumBackend {
             return new BlockInfo(block.getNumber().longValue(), receiptList);
         } catch (Throwable ex) {
             logger.error("error while converting to block info", ex);
-            throw new EthereumApiException("error while converting to block info", ex);
+            return new BlockInfo(block.getNumber().longValue(), Collections.emptyList());
         }
 
     }


### PR DESCRIPTION
Propagation of this exception blocks the events/tx observers.
This happens approx once a week on Rinkeby, perhaps due to the block forks, when txs from a block are examined but their receipts cannot be (anymore) fetched via RPC.